### PR TITLE
wrong decoding for numbers 4096 - 168xx, bad shifting otherwise

### DIFF
--- a/Polkadot.BinarySerializer/Scale.cs
+++ b/Polkadot.BinarySerializer/Scale.cs
@@ -147,7 +147,7 @@ namespace Polkadot.BinarySerializer
             {
                 b.Length = 2;
                 b.Bytes[0] = (byte)(((n & 0x3F) << 2) | 0x01);
-                b.Bytes[1] = (byte)((n & 0xFC0) >> 6);
+                b.Bytes[1] = (byte)((n & 0xFFC0) >> 6);
             }
             else if (n <= 0x3FFFFFFF)
             {


### PR DESCRIPTION
fixed with following test cases the issue can be verified.

```
        [Test]
        public void EncodeDecodeTest2()
        {
            for (int i = 0; i < 1000000; i++)
            {
                CompactInteger c = i;
                Assert.AreEqual(c, CompactInteger.Decode(c.Encode()));
            }
        }
```